### PR TITLE
register Test::DistManifest as a prereq and fail if it is not available

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/DistManifest.pm
+++ b/lib/Dist/Zilla/Plugin/Test/DistManifest.pm
@@ -7,6 +7,19 @@ package Dist::Zilla::Plugin::Test::DistManifest;
 # VERSION
 use Moose;
 extends 'Dist::Zilla::Plugin::InlineFiles';
+with 'Dist::Zilla::Role::PrereqSource';
+
+sub register_prereqs
+{
+    my $self = shift;
+    $self->zilla->register_prereqs(
+        {
+            type  => 'requires',
+            phase => 'develop',
+        },
+        'Test::DistManifest' => 0,
+    );
+}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;
@@ -33,11 +46,9 @@ following file:
 
 __DATA__
 ___[ xt/release/dist-manifest.t ]___
-#!perl
-
+use strict;
+use warnings;
 use Test::More;
 
-eval "use Test::DistManifest";
-plan skip_all => "Test::DistManifest required for testing the manifest"
-  if $@;
+use Test::DistManifest;
 manifest_ok();


### PR DESCRIPTION
If Test::DistManifest is not installed, the generated test would just
skip itself. Since it is an author test, it shouldn't ignore errors like
this.

Register Test::DistManifest as a develop prereq, so that it can be
installed automatically by tooling, and make the test just use the
module directly rather than skipping on load failures.